### PR TITLE
Switch testing instructions above the button

### DIFF
--- a/lib/views/organisms/practice/impression_hidden.dart
+++ b/lib/views/organisms/practice/impression_hidden.dart
@@ -28,26 +28,24 @@ class ImpressionHidden extends StatelessWidget {
                 text,
                 backgroundCards: cardsRemaining,
               ),
-              Column(children: [
-                Button(
-                  'Reveal answer',
-                  revealAnswer,
-                  type: ButtonType.primaryProgress,
-                  progressPercentage: timeElapsedPercentage,
-                  icon: Icons.remove_red_eye_outlined,
-                  size: ButtonSize.big,
-                  shortcut: '⏎',
-                ),
-                Padding(
-                    padding: topPadding(PaddingType.xxLarge),
-                    child: DescriptionRichText([
-                      const TextSpan(text: 'Try to remember '),
-                      TextSpan(
-                          text: hintText,
-                          style: const TextStyle(fontWeight: FontWeight.w900)),
-                      const TextSpan(text: ' for this card.')
-                    ]))
-              ])
+              Padding(
+                  padding: bottomPadding(PaddingType.xLarge),
+                  child: DescriptionRichText([
+                    const TextSpan(text: 'Try to remember '),
+                    TextSpan(
+                        text: hintText,
+                        style: const TextStyle(fontWeight: FontWeight.w900)),
+                    const TextSpan(text: ' for this card.')
+                  ])),
+              Button(
+                'Reveal answer',
+                revealAnswer,
+                type: ButtonType.primaryProgress,
+                progressPercentage: timeElapsedPercentage,
+                icon: Icons.remove_red_eye_outlined,
+                size: ButtonSize.big,
+                shortcut: '⏎',
+              )
             ])));
   }
 }


### PR DESCRIPTION
Based on user session feedback

After:

![image](https://user-images.githubusercontent.com/2202487/168491166-39b8400b-45e4-4668-a7ab-e52a0dba61e7.png)
